### PR TITLE
Remove the floating option from text of a pie chart.

### DIFF
--- a/lib/highcharts_on_rails/pie_chart.rb
+++ b/lib/highcharts_on_rails/pie_chart.rb
@@ -6,7 +6,6 @@ class HighchartsOnRails::PieChart < HighchartsOnRails::BaseChart
                        fontWeight: 'bold'
                    },
                    text: "",
-                   floating: true
                },
                xAxis: {
                    categories: nil


### PR DESCRIPTION
It causes overflowing a subtitle by the main title in a pie chart. 

Here's an example: https://www.dropbox.com/s/06xl18001ivpd18/Screenshot%202014-04-02%2013.11.44.png
